### PR TITLE
use first path in result list

### DIFF
--- a/autoload/deopleteruby.vim
+++ b/autoload/deopleteruby.vim
@@ -18,7 +18,7 @@ function! deopleteruby#build_cache()
         \ ]
 
   for source_file in source_files
-    let meths = readfile(globpath(&rtp, source_file))
+    let meths = readfile(globpath(&rtp, source_file, 0, 1)[0])
 
     for meth in meths
       let cache = {}


### PR DESCRIPTION
For me, `globpath` was returning a newline separated list of file names, which `readfile` choked on. This takes the first result.

I am not sure if this is indicative of some other problem occurring, or if there is a better solution, but this worked for me.